### PR TITLE
Create missing 'crypto' directory in 'obj' directory

### DIFF
--- a/src/obj/.gitignore
+++ b/src/obj/.gitignore
@@ -1,2 +1,3 @@
 *
+!crypto
 !.gitignore

--- a/src/obj/crypto/.gitignore
+++ b/src/obj/crypto/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
Create missing 'crypto' directory in 'obj' directory to enable compilation.